### PR TITLE
Ajustando local do contrato

### DIFF
--- a/Interview/Scenes/ListContacts/Models/Contact.swift
+++ b/Interview/Scenes/ListContacts/Models/Contact.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+/*
+ Json Contract
+[
+  {
+    "id": 1,
+    "name": "Shakira",
+    "photoURL": "https://api.adorable.io/avatars/285/a1.png"
+  }
+]
+*/
+
 class Contact: Codable {
     var id: Int
     var name: String = ""

--- a/Interview/Scenes/ListContacts/Services/ListContactsService.swift
+++ b/Interview/Scenes/ListContacts/Services/ListContactsService.swift
@@ -2,17 +2,6 @@ import Foundation
 
 private let apiURL = "https://run.mocky.io/v3/d26d86ec-fb82-48a7-9c73-69e2cb728070"
 
-/*
- Json Contract
-[
-  {
-    "id": 1,
-    "name": "Shakira",
-    "photoURL": "https://api.adorable.io/avatars/285/a1.png"
-  }
-]
-*/
-
 class ListContactService {
     func fetchContacts(completion: @escaping ([Contact]?, Error?) -> Void) {
         guard let api = URL(string: apiURL) else {


### PR DESCRIPTION
Percebi que durante as entrevistas sempre precisamos redirecionar o candidato ao arquivo da Service para que o mesmo consiga visualizar o contrato que é utilizado, para facilitar isso, acho que seria uma boa deixar esse contrato direto na Model.